### PR TITLE
Fix StaticFiles mount order

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,11 +8,6 @@ from datetime import datetime
 
 app = FastAPI(title="Order‑Scanner API")
 
-# ---------- NEW: serve React bundle ----------
-static_path = os.getenv("STATIC_FILES_PATH", "static")   # set in Dockerfile
-app.mount("/", StaticFiles(directory=static_path, html=True), name="static")
-# ------------------------------------------------
-
 @app.on_event("startup")
 async def _init():
     async with database.engine.begin() as conn:
@@ -83,6 +78,9 @@ async def tag_summary():
                 if k in low:
                     counts[k] += 1
     return counts
+
+static_path = os.getenv("STATIC_FILES_PATH", "static")
+app.mount("/", StaticFiles(directory=static_path, html=True), name="static")
 
 @app.get("/health")
 def health():


### PR DESCRIPTION
## Summary
- register FastAPI static files handler after API route registration

## Testing
- `python3 -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_687edf79bd1c8321bd48d6db671c93ec