### PR TITLE
Fix static mount order

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,9 +79,9 @@ async def tag_summary():
                     counts[k] += 1
     return counts
 
-static_path = os.getenv("STATIC_FILES_PATH", "static")
-app.mount("/", StaticFiles(directory=static_path, html=True), name="static")
-
 @app.get("/health")
 def health():
     return {"ok": True}
+
+static_path = os.getenv("STATIC_FILES_PATH", "static")
+app.mount("/", StaticFiles(directory=static_path, html=True), name="static")


### PR DESCRIPTION
## Summary
- ensure StaticFiles is mounted after the `/health` route so API routes are not shadowed

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee2e5948883218a706c2605a160be