### PR TITLE
Add basic unit test for main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Minimal reproduction of your Apps‑Script barcode scanner as a FastAPI + React 
 
 See the docs in the main ChatGPT answer for environment variables and deployment.
 
+## Running the Tests
+
+Install backend dependencies and execute `pytest` from the repository root:
+
+```bash
+pip install -r backend/requirements.txt
+pytest
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,29 @@
+import pytest
+from fastapi.testclient import TestClient
+from pathlib import Path
+import sys
+import os
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("STATIC_FILES_PATH", "static")
+Path("static").mkdir(exist_ok=True)
+from backend.app.main import app, _clean
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+def test_clean_valid():
+    assert _clean("00123") == "#123"
+    assert _clean("abc123def") == "#123"
+
+def test_clean_invalid():
+    with pytest.raises(ValueError):
+        _clean("abc")
+    with pytest.raises(ValueError):
+        _clean("1234567")
+


### PR DESCRIPTION
## Summary
- add unit tests covering `_clean` and health endpoint
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff08be5908321ad026f2386de3ac2