### PR TITLE
Add missing backend test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See the docs in the main ChatGPT answer for environment variables and deployment
 
 ## Running the Tests
 
-Install backend dependencies and execute `pytest` from the repository root:
+Install backend dependencies (including the test requirements) and execute `pytest` from the repository root:
 
 ```bash
 pip install -r backend/requirements.txt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,6 @@ pydantic
 gspread==6.*        # optional Google Sheets
 google-auth
 python-multipart
+httpx
+aiosqlite
+pytest


### PR DESCRIPTION
## Summary
- add httpx, aiosqlite and pytest to backend requirements
- clarify README that requirements include test dependencies

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff9b6f730832193d3ae1365c00f0e