### PR TITLE
Fix timezone handling in Shopify module

### DIFF
--- a/backend/app/shopify.py
+++ b/backend/app/shopify.py
@@ -4,7 +4,7 @@ import base64
 import json
 import os
 import re
-from datetime import datetime as dt
+import datetime as dt
 from typing import Any, Dict, List
 
 
@@ -98,7 +98,7 @@ async def find_order(order_name: str) -> Dict[str, str]:
 
     Returns the first recent match (newest order within ORDER_CUTOFF_DAYS).
     """
-    now = dt.datetime.utcnow()
+    now = dt.datetime.now(dt.timezone.utc)
     cutoff = now - dt.timedelta(days=CONFIG["ORDER_CUTOFF_DAYS"])
     best: Dict[str, str] = {
         "tags": "",

--- a/backend/tests/test_shopify.py
+++ b/backend/tests/test_shopify.py
@@ -1,0 +1,31 @@
+import asyncio
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from backend.app import shopify
+
+
+def test_find_order_returns_dict(monkeypatch):
+    async def fake_fetch_order(session, store, name):
+        return {
+            "tags": "foo",
+            "fulfillment_status": "fulfilled",
+            "created_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "cancelled_at": None,
+        }
+
+    monkeypatch.setattr(shopify, "_fetch_order", fake_fetch_order)
+    monkeypatch.setattr(
+        shopify,
+        "_stores",
+        lambda: [{"name": "test", "api_key": "x", "password": "y", "domain": "z"}],
+    )
+
+    result = asyncio.run(shopify.find_order("#123"))
+    assert result["result"] == "✅ OK"
+    assert result["store"] == "test"
+


### PR DESCRIPTION
## Summary
- fix timezone aware datetime usage in shopify.find_order
- add regression test for shopify.find_order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688144400158832192e45aacdf421c46