### PR TITLE
Fix Pydantic example warning

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,9 @@ from datetime import datetime
 
 
 class ScanIn(BaseModel):
-    barcode: str = Field(..., example="#123456")
+    barcode: str = Field(
+        ..., json_schema_extra={"example": "#123456"}
+    )
 
 
 class ScanOut(BaseModel):


### PR DESCRIPTION
## Summary
- use `json_schema_extra` when defining `ScanIn.barcode` field to avoid Pydantic deprecation warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814b96042083218892a44b036eb4a3