### PR TITLE
Fix default API URL in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ npm run build
 This produces a `dist/` folder that can be served by the API container.  When
 developing locally with `npm run dev` make sure the `VITE_API_BASE_URL`
 environment variable points at your API instance so the app can reach the
-backend.
+backend. The build step can also make use of this variable, but if it is not
+defined the UI will fall back to using the same origin as the page, which works
+for single-container deployments.
 
 ## Running the Tests
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles        # ← NEW
+from fastapi.staticfiles import StaticFiles
 from .schemas import ScanIn, ScanOut
 from . import shopify, database, models, sheets
 from sqlalchemy import select
@@ -15,10 +15,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="Order‑Scanner API")
-
-static_path = os.getenv("STATIC_FILES_PATH", "static")
-app.mount("/", StaticFiles(directory=static_path, html=True), name="static")
+app = FastAPI(title="Order‑Scanner API", lifespan=lifespan)
 
 _barcode_re = re.compile(r"\d+")
 
@@ -113,4 +110,9 @@ async def tag_summary():
 @app.get("/health")
 def health():
     return {"ok": True}
+
+
+# Serve built frontend files if available
+static_path = os.getenv("STATIC_FILES_PATH", "static")
+app.mount("/", StaticFiles(directory=static_path, html=True), name="static")
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { Html5Qrcode } from "html5-qrcode";
 
+// Allow using a relative URL when VITE_API_BASE_URL is undefined.
+const apiBase = import.meta.env.VITE_API_BASE_URL || "";
+
 const tagColors = {
   k: "#ffc0cb",
   big: "#fff176",
@@ -64,7 +67,7 @@ export default function App() {
 
   async function processScan(barcode) {
     try {
-      const resp = await fetch(`${import.meta.env.VITE_API_BASE_URL}/scan`, {
+      const resp = await fetch(`${apiBase}/scan`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ barcode }),
@@ -100,7 +103,7 @@ export default function App() {
   }
 
   async function fetchSummary() {
-    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/tag-summary`);
+    const res = await fetch(`${apiBase}/tag-summary`);
     const data = await res.json();
     setSummary(data);
   }


### PR DESCRIPTION
## Summary
- support a missing `VITE_API_BASE_URL` in React app
- register FastAPI lifespan to create DB tables
- mount static files after API routes
- document API URL behaviour in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688221757ccc83218a7ed8a13f6cacd1