### PR TITLE
Fix tag summary query with SQLAlchemy text

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from .schemas import ScanIn, ScanOut
 from . import shopify, database, models, sheets
-from sqlalchemy import select
+from sqlalchemy import select, text
 import os
 import re
 from contextlib import asynccontextmanager
@@ -89,7 +89,7 @@ async def scan(data: ScanIn):
 @app.get("/tag-summary")
 async def tag_summary():
     async with database.AsyncSessionLocal() as db:
-        q = await db.execute("SELECT tags FROM scans")
+        q = await db.execute(text("SELECT tags FROM scans"))
         counts = {
             "k": 0,
             "big": 0,


### PR DESCRIPTION
## Summary
- import `text` from SQLAlchemy
- use `text("SELECT tags FROM scans")` when executing the tag summary query

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688234a031f8832181b503f7b9363e5c