### PR TITLE
Normalize Shopify store domains

### DIFF
--- a/backend/tests/test_shopify.py
+++ b/backend/tests/test_shopify.py
@@ -29,3 +29,10 @@ def test_find_order_returns_dict(monkeypatch):
     assert result["result"] == "✅ OK"
     assert result["store"] == "test"
 
+
+def test_sanitize_domain():
+    assert (
+        shopify._sanitize_domain("https://demo.myshopify.com/")
+        == "demo.myshopify.com"
+    )
+


### PR DESCRIPTION
## Summary
- add `_sanitize_domain` helper to clean up Shopify domains
- normalize store domains from environment variables and JSON
- test domain normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688234a751c483218e62cece745e69ae