### PR TITLE
Handle null fulfillment status from Shopify

### DIFF
--- a/backend/app/shopify.py
+++ b/backend/app/shopify.py
@@ -134,11 +134,12 @@ async def find_order(order_name: str) -> Dict[str, str]:
                     if created < cutoff:
                         break  # too old
                     best = {
-                        "tags": order.get("tags", ""),
-                        "fulfillment": order.get(
-                            "fulfillment_status",
-                            "unfulfilled",
-                        ),
+                        # Shopify may return null for certain fields. Fallback
+                        # to sensible defaults in that case so downstream code
+                        # can safely rely on string values.
+                        "tags": order.get("tags") or "",
+                        "fulfillment": order.get("fulfillment_status")
+                        or "unfulfilled",
                         "status": (
                             "closed" if order.get("cancelled_at") else "open"
                         ),

--- a/backend/tests/test_shopify.py
+++ b/backend/tests/test_shopify.py
@@ -41,3 +41,24 @@ def test_normalize_domain_env(monkeypatch):
     stores = shopify._stores()
     assert stores[0]["domain"] == "example.myshopify.com"
 
+
+def test_fulfillment_defaults_to_unfulfilled(monkeypatch):
+    async def fake_fetch_order(session, store, name):
+        return {
+            "tags": "",
+            "fulfillment_status": None,
+            "created_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "cancelled_at": None,
+        }
+
+    monkeypatch.setattr(shopify, "_fetch_order", fake_fetch_order)
+    monkeypatch.setattr(
+        shopify,
+        "_stores",
+        lambda: [{"name": "test", "api_key": "x", "password": "y", "domain": "z"}],
+    )
+
+    result = asyncio.run(shopify.find_order("#123"))
+    assert result["fulfillment"] == "unfulfilled"
+    assert result["result"] == "❌ Unfulfilled"
+


### PR DESCRIPTION
## Summary
- fix handling of `fulfillment_status` when Shopify returns `null`
- add regression tests for defaulting to "unfulfilled"
- test API behaviour for unfulfilled orders with no tag

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882430eab94832194f51f11b7554e41