### PR TITLE
Fix Shopify order lookup for barcodes

### DIFF
--- a/backend/app/shopify.py
+++ b/backend/app/shopify.py
@@ -88,13 +88,11 @@ def _auth_hdr(api_key: str, password: str) -> Dict[str, str]:
 async def _fetch_order(
     session: aiohttp.ClientSession, store: Dict[str, str], name: str
 ) -> Dict[str, Any] | None:
-    url = (
-        f"https://{store['domain']}/admin/api/2023-07/orders.json?"
-        f"status=any&name={name}"
-    )
+    url = f"https://{store['domain']}/admin/api/2023-07/orders.json"
     async with session.get(
         url,
         headers=_auth_hdr(store["api_key"], store["password"]),
+        params={"status": "any", "name": name},
     ) as r:
         if r.status != 200:
             raise RuntimeError(f"{store['name']} responded {r.status}")

--- a/backend/tests/test_shopify.py
+++ b/backend/tests/test_shopify.py
@@ -62,3 +62,31 @@ def test_fulfillment_defaults_to_unfulfilled(monkeypatch):
     assert result["fulfillment"] == "unfulfilled"
     assert result["result"] == "❌ Unfulfilled"
 
+
+def test_fetch_order_uses_query_params():
+    captured = {}
+
+    class FakeResp:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def json(self):
+            return {"orders": [None]}
+
+    class FakeSession:
+        def get(self, url, headers=None, params=None):
+            captured["url"] = url
+            captured["params"] = params
+            return FakeResp()
+
+    store = {"domain": "example.myshopify.com", "api_key": "k", "password": "p"}
+
+    asyncio.run(shopify._fetch_order(FakeSession(), store, "#123"))
+
+    assert captured["params"] == {"status": "any", "name": "#123"}
+


### PR DESCRIPTION
## Summary
- URL-encode order names in Shopify API requests
- add regression test verifying query parameters

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826b8ef2048321be124d3a9b7abfb3