### PR TITLE
Fix delivery tag detection with whitespace

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,13 +32,20 @@ DELIVERY_TAGS = [
 
 
 def _detect_delivery_tag(tag_str: str) -> str:
-    """Return the first known delivery tag found in *tag_str* (case-insensitive).
+    """Return the first known delivery tag found in *tag_str*.
 
-    The *tag_str* may contain a comma separated list of tags.  Each token is
-    matched individually against :data:`DELIVERY_TAGS` using case-insensitive
-    equality.
+    Shopify stores tags as a comma separated list, however some installations
+    have been observed to use spaces instead.  To make the detection more
+    resilient we split the string on commas **and** whitespace.  Each resulting
+    token is then matched (case-insensitively) against
+    :data:`DELIVERY_TAGS`.
     """
-    tokens = [(t or "").strip().lower() for t in (tag_str or "").split(",")]
+
+    import re
+
+    tokens = re.split(r"[,\s]+", tag_str or "")
+    tokens = [t.strip().lower() for t in tokens if t.strip()]
+
     for tag in DELIVERY_TAGS:
         for tok in tokens:
             if tok == tag:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -170,6 +170,8 @@ def test_scan_filters_tags(client, monkeypatch):
 def test_detect_delivery_tag_exact_match():
     assert _detect_delivery_tag("fast, urgent") == "fast"
     assert _detect_delivery_tag("K, other") == "k"
+    # whitespace should also work as a delimiter
+    assert _detect_delivery_tag("fast urgent") == "fast"
     # partial words should not match
     assert _detect_delivery_tag("snack") == ""
 


### PR DESCRIPTION
## Summary
- handle whitespace or comma separated tags in `_detect_delivery_tag`
- test detecting delivery tags separated by spaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827795acc083218e7fffd7267aef5c