### PR TITLE
Handle missing Shopify orders gracefully

### DIFF
--- a/backend/app/shopify.py
+++ b/backend/app/shopify.py
@@ -97,7 +97,11 @@ async def _fetch_order(
         if r.status != 200:
             raise RuntimeError(f"{store['name']} responded {r.status}")
         data = await r.json()
-    return data.get("orders", [None])[0]
+
+    orders = data.get("orders")
+    if not orders:
+        return None
+    return orders[0]
 
 # ---------------- public API ------------------
 

--- a/backend/tests/test_shopify.py
+++ b/backend/tests/test_shopify.py
@@ -90,3 +90,22 @@ def test_fetch_order_uses_query_params():
 
     assert captured["params"] == {"status": "any", "name": "#123"}
 
+
+def test_fetch_order_empty_list_returns_none():
+    class FakeResp:
+        status = 200
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def json(self):
+            return {"orders": []}
+
+    class FakeSession:
+        def get(self, url, headers=None, params=None):
+            return FakeResp()
+
+    store = {"domain": "example.myshopify.com", "api_key": "k", "password": "p"}
+
+    result = asyncio.run(shopify._fetch_order(FakeSession(), store, "#123"))
+    assert result is None


### PR DESCRIPTION
## Summary
- avoid IndexError when Shopify returns an empty `orders` array
- test `_fetch_order` with empty results

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827cc4eddc83219e3a4f611ad8e261