### PR TITLE
Enhance mobile layout for order scanner

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,7 @@ body {
   text-align: center;
   margin: 0;
   padding: 1rem;
+  padding-bottom: 5rem;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   min-height: 100vh;
   color: #333;
@@ -49,32 +50,71 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:2.5rem; font-weight:700; text-sh
   font-size:1.5rem; font-weight:700; color:#4c51bf; margin-bottom:1rem; padding-bottom:0.5rem;
   border-bottom:3px solid #e5e7eb; display:flex; align-items:center; gap:0.5rem;
 }
-#orderList { list-style:none; padding:0; margin:0 0 2rem 0; max-height:400px; overflow-y:auto; }
+#orderList {
+  list-style:none;
+  padding:0;
+  margin:0 0 2rem 0;
+  max-height:400px;
+  overflow-y:auto;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
 .order-item {
-  margin-bottom:1rem; padding:1.2rem; border-radius:12px; background:#f8fafc;
-  border-left:5px solid #e5e7eb; box-shadow:0 2px 8px rgba(0,0,0,0.1);
-  transition:all 0.3s ease; animation:slideInFromTop 0.5s ease-out;
+  margin-bottom:0;
+  padding:8px 12px;
+  border-radius:12px;
+  background:#f8fafc;
+  border-left:5px solid #e5e7eb;
+  box-shadow:0 2px 8px rgba(0,0,0,0.1);
+  transition:all 0.3s ease;
+  animation:slideInFromTop 0.5s ease-out;
 }
 .order-item:hover { transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,0.15); }
 .order-item.success { border-left-color:#10b981; background:linear-gradient(90deg,rgba(16,185,129,0.1) 0%,#f8fafc 100%); }
 .order-item.warning { border-left-color:#f59e0b; background:linear-gradient(90deg,rgba(245,158,11,0.1) 0%,#f8fafc 100%); }
 .order-item.error { border-left-color:#ef4444; background:linear-gradient(90deg,rgba(239,68,68,0.1) 0%,#f8fafc 100%); }
 .order-status { font-weight:700; font-size:1.1rem; margin-bottom:0.5rem; }
-.order-details { display:flex; flex-wrap:wrap; gap:1rem; align-items:center; }
+.order-details {
+  display:flex;
+  flex-wrap:wrap;
+  gap:0.5rem;
+  align-items:center;
+}
 .order-name {
-  font-family:'Courier New', monospace; font-weight:1000; font-size:2rem; color:#1f2937;
-  background:rgba(255,255,255,0.95); padding:0.8rem 1.2rem; border-radius:12px;
-  border:3px solid #4c51bf; box-shadow:0 4px 12px rgba(0,0,0,0.15); letter-spacing:2px;
+  font-family:'Courier New', monospace;
+  font-weight:700;
+  font-size:22px;
+  color:#1f2937;
+  background:rgba(255,255,255,0.95);
+  padding:0.4rem 0.6rem;
+  border-radius:12px;
+  border:2px solid #4c51bf;
+  box-shadow:0 4px 12px rgba(0,0,0,0.15);
+  letter-spacing:1px;
   text-shadow:1px 1px 2px rgba(0,0,0,0.1);
 }
 .tag-count, .order-tag {
-  display:inline-block; padding:0.4em 1em; margin:0.2em; border-radius:25px;
-  font-weight:700; color:#333; font-size:2rem; text-transform:uppercase; letter-spacing:0.5px;
-  box-shadow:0 2px 6px rgba(0,0,0,0.1); border:2px solid rgba(255,255,255,0.5);
+  display:inline-block;
+  padding:0.2em 0.6em;
+  margin:0.2em;
+  border-radius:25px;
+  font-weight:bold;
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.5px;
+  box-shadow:0 2px 6px rgba(0,0,0,0.1);
+  border:2px solid rgba(255,255,255,0.5);
 }
 #tagSummary { display:flex; flex-wrap:wrap; gap:0.8rem; justify-content:center; }
-.tag-count { transition:all 0.3s ease; cursor:default; }
-.tag-count:hover { transform:scale(1.05); box-shadow:0 4px 12px rgba(0,0,0,0.2); }
+.tag-count {
+  transition:all 0.3s ease;
+  cursor:default;
+}
+.tag-count:hover {
+  transform:scale(1.05);
+  box-shadow:0 4px 12px rgba(0,0,0,0.2);
+}
 .status-indicator { width:12px; height:12px; border-radius:50%; display:inline-block; margin-right:0.5rem; box-shadow:0 2px 4px rgba(0,0,0,0.2); }
 .status-success { background:#10b981; }
 .status-warning { background:#f59e0b; }
@@ -82,8 +122,28 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:2.5rem; font-weight:700; text-sh
 @keyframes slideInFromTop { from { opacity:0; transform:translateY(-20px); } to { opacity:1; transform:translateY(0); } }
 @keyframes pulse { 0%,100% { transform:scale(1); } 50% { transform:scale(1.05); } }
 .scanning { animation:pulse 2s infinite; }
+.tag-bar,
+#tagBar {
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  padding:8px;
+  background:#fff;
+  display:flex;
+  gap:8px;
+  overflow-x:auto;
+  box-shadow:0 -2px 8px rgba(0,0,0,0.2);
+  z-index:100;
+}
+.tag-chip {
+  flex:0 0 auto;
+}
+.tag-chip.active {
+  box-shadow:0 0 0 2px #4c51bf;
+}
 @media (max-width:768px) {
-  body { padding:0.5rem; }
+  body { padding:0.5rem; padding-bottom:4rem; }
   h1 { font-size:2rem; }
   .header { padding:1.5rem; }
   .scan-btn { padding:1rem 2rem; font-size:1.3rem; }


### PR DESCRIPTION
## Summary
- make scan list filterable by tag
- add sticky tag bar with counts
- refine order cards and badges for mobile view

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688284d32a3c83219f4e09391f99f5e1