### PR TITLE
Tighter recent scan list

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -151,13 +151,12 @@ export default function App() {
                 {o.result}
               </div>
               <div className="order-details">
-                <span className="order-name">{o.order}</span>
                 <span
-                  className="order-tag"
-                  style={{ background: tagColors[o.tag] || tagColors["none"] }}
+                  className={`order-tag ${statusClass(o.result)}`}
                 >
                   {o.tag || "No tag"}
                 </span>
+                <span className="order-name">{o.order}</span>
               </div>
             </li>
           ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,18 +62,21 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-sh
 .order-item.error { border-left-color:#ef4444; background:linear-gradient(90deg,rgba(239,68,68,0.1) 0%,#f8fafc 100%); }
 .order-status { font-weight:700; font-size:0.9rem; margin-bottom:0.5rem; }
 .order-details { display:flex; flex-wrap:wrap; gap:1rem; align-items:center; }
+#tagSummary { display:flex; flex-wrap:wrap; gap:0.4rem; justify-content:center; max-height:4rem; overflow-y:auto; }
 .order-name {
-  font-family:'Courier New', monospace; font-weight:1000; font-size:2rem; color:#1f2937;
-  background:rgba(255,255,255,0.95); padding:0.8rem 1.2rem; border-radius:12px;
-  border:3px solid #4c51bf; box-shadow:0 4px 12px rgba(0,0,0,0.15); letter-spacing:2px;
+  font-family:'Courier New', monospace; font-weight:700; font-size:1.3rem; color:#1f2937;
+  background:rgba(255,255,255,0.95); padding:0.4rem 0.6rem; border-radius:8px;
+  border:2px solid #4c51bf; box-shadow:0 2px 6px rgba(0,0,0,0.15); letter-spacing:1px;
   text-shadow:1px 1px 2px rgba(0,0,0,0.1);
 }
 .tag-count, .order-tag {
-  display:inline-block; padding:0.4em 1em; margin:0.2em; border-radius:25px;
-  font-weight:700; color:#333; font-size:2rem; text-transform:uppercase; letter-spacing:0.5px;
-  box-shadow:0 2px 6px rgba(0,0,0,0.1); border:2px solid rgba(255,255,255,0.5);
+  display:inline-block; padding:0.2em 0.6em; margin:0.1em; border-radius:20px;
+  font-weight:700; color:#333; font-size:1rem; text-transform:uppercase; letter-spacing:0.5px;
+  box-shadow:0 1px 3px rgba(0,0,0,0.1); border:2px solid rgba(255,255,255,0.5);
 }
-#tagSummary { display:flex; flex-wrap:wrap; gap:0.8rem; justify-content:center; }
+.order-tag.success { background:rgba(16,185,129,0.2); border-color:#10b981; }
+.order-tag.warning { background:rgba(245,158,11,0.2); border-color:#f59e0b; }
+.order-tag.error { background:rgba(239,68,68,0.2); border-color:#ef4444; }
 .tag-count { transition:all 0.3s ease; cursor:pointer; }
 .tag-count:hover { transform:scale(1.05); box-shadow:0 4px 12px rgba(0,0,0,0.2); }
 .tag-count.active { outline:3px solid #4c51bf; }
@@ -102,5 +105,5 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-sh
   .header { padding:1.5rem; }
   .scan-btn { padding:1rem 2rem; font-size:1.3rem; }
   .order-details { flex-direction:column; align-items:flex-start; }
-  .order-name { font-size:1.8rem; padding:0.6rem 1rem; }
+  .order-name { font-size:1.2rem; padding:0.4rem 0.6rem; }
 }


### PR DESCRIPTION
## Summary
- show order tag before the order number
- shrink tag summary area and recent scan fonts
- color tags by scan result

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828ed796008321a4e0f550b9b5fc5a