### PR TITLE
Add Scanned Orders tab

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Integer
+from sqlalchemy import Column, String, DateTime, Integer, Boolean
 from .database import Base
 from datetime import datetime
 
@@ -13,3 +13,5 @@ class Scan(Base):
     status = Column(String)
     store = Column(String)
     result = Column(String)
+    driver = Column(String, default="")
+    cod = Column(Boolean, default=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -13,3 +13,22 @@ class ScanOut(BaseModel):
     order: str
     tag: str
     ts: datetime
+
+
+class ScanRecord(BaseModel):
+    id: int
+    ts: datetime
+    order_name: str
+    tags: str | None
+    fulfillment: str | None
+    status: str | None
+    store: str | None
+    result: str | None
+    driver: str | None = ""
+    cod: bool | None = False
+
+
+class ScanUpdate(BaseModel):
+    tags: str | None = None
+    driver: str | None = None
+    status: str | None = None

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -237,3 +237,20 @@ def test_tag_summary_by_store(client, monkeypatch):
     after = client.get("/tag-summary/by-store").json()
     assert after.get("irrakids", {}).get("fast", 0) >= before.get("irrakids", {}).get("fast", 0) + 1
     assert after.get("irranova", {}).get("k", 0) >= before.get("irranova", {}).get("k", 0) + 1
+
+
+def test_list_and_update_scans(client):
+    today = datetime.datetime.utcnow().date().isoformat()
+    client.post("/scan", json={"barcode": "601"})
+    resp = client.get(f"/scans?date={today}")
+    assert resp.status_code == 200
+    scans = resp.json()
+    assert len(scans) >= 1
+    first_id = scans[0]["id"]
+
+    update = {"driver": "alice", "tags": "fast", "status": "dispatched"}
+    resp = client.patch(f"/scans/{first_id}", json=update)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["driver"] == "alice"
+    assert data["status"] == "dispatched"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,22 @@ body {
   color: #333;
 }
 .container { max-width: 800px; margin: 0 auto; }
+.tab-bar { display:flex; gap:0.5rem; margin-bottom:1rem; justify-content:center; }
+.tab-bar button { padding:0.4rem 1rem; border:none; border-radius:8px; cursor:pointer; }
+.tab-bar .active { background:#4c51bf; color:#fff; }
+.toast { position:fixed; top:1rem; right:1rem; background:#10b981; color:#fff; padding:0.5rem 1rem; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.2); }
+.table-card { background:#fff; padding:1rem; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.2); }
+.scans-table { width:100%; border-collapse:collapse; font-size:0.9rem; }
+.scans-table th, .scans-table td { padding:0.4rem; border-bottom:1px solid #ddd; }
+.scans-table tr:nth-child(even) { background:#f9f9f9; }
+.scans-table tr.flash { animation:flashBg 1s; }
+.scans-table tr.missing-tag { background:#fff8c5; }
+.filters { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center; margin-bottom:0.5rem; }
+.tag-pills { display:flex; flex-wrap:wrap; gap:0.4rem; }
+.tag-pill { padding:0.3rem 0.6rem; border-radius:20px; cursor:pointer; background:#eee; }
+.tag-pill.active { outline:2px solid #4c51bf; }
+.totals { margin-top:0.5rem; font-weight:600; }
+@keyframes flashBg { from { background:#d1fae5; } to { background:inherit; } }
 .header {
   background: rgba(255,255,255,0.95);
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- track driver and COD status in the Scan model
- expose `/scans` GET and PATCH endpoints
- list and edit scans from a new tab in the React UI
- style table and controls
- cover new API features with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882913c63cc8321b19d8753be6ea4ea