### PR TITLE
Revamp scan UI spacing and tag colors

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,18 @@ export default function App() {
     }
   }, [tab, scanDate, scanTag]);
 
+  function hideLibraryInfo() {
+    const root = readerRef.current;
+    if (!root) return;
+    const infoIcon = root.querySelector('img[alt="Info icon"]');
+    if (infoIcon) infoIcon.remove();
+    root.querySelectorAll('div').forEach((d) => {
+      if (d.textContent && d.textContent.includes('Powered by')) {
+        d.remove();
+      }
+    });
+  }
+
   function startScanner() {
     setResult("📱 Point your camera at a QR code...");
     setResultClass("");
@@ -78,14 +90,16 @@ export default function App() {
     if (!qr) {
       qr = new Html5Qrcode(readerRef.current.id);
       scannerRef.current = qr;
-      qr.start({ facingMode: "environment" }, config, onScan, () => {})
+      qr
+        .start({ facingMode: "environment" }, config, onScan, () => {})
+        .then(hideLibraryInfo)
         .catch(() => {
           handleScanError("Camera access denied or not available");
           setScanning(false);
           setShowStart(true);
         });
     } else {
-      qr.resume();
+      qr.resume().then(hideLibraryInfo);
     }
   }
 
@@ -208,7 +222,12 @@ export default function App() {
               {displayedOrders.map((o, i) => (
                 <li key={i} className={`order-item ${statusClass(o.result)}`}>
                   <span className="order-name">{o.order}</span>
-                  <span className={`order-tag ${statusClass(o.result)}`}>{o.tag || "No tag"}</span>
+                  <span
+                    className="order-tag"
+                    style={{ background: tagColors[(o.tag || "none").toLowerCase()] || tagColors["none"] }}
+                  >
+                    {o.tag || "No tag"}
+                  </span>
                   <span className="order-status-text">{o.result}</span>
                 </li>
               ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,8 +10,18 @@ body {
 }
 .container { max-width: 800px; margin: 0 auto; }
 .tab-bar { display:flex; gap:0.5rem; margin-bottom:1rem; justify-content:center; }
-.tab-bar button { padding:0.4rem 1rem; border:none; border-radius:8px; cursor:pointer; }
-.tab-bar .active { background:#4c51bf; color:#fff; }
+.tab-bar button {
+  padding:0.6rem 1.2rem;
+  border:none;
+  border-radius:10px;
+  cursor:pointer;
+  font-size:1rem;
+}
+.tab-bar .active {
+  background:linear-gradient(135deg,#4c51bf 0%,#667eea 100%);
+  color:#fff;
+  box-shadow:0 4px 12px rgba(0,0,0,0.2);
+}
 .toast { position:fixed; top:1rem; right:1rem; background:#10b981; color:#fff; padding:0.5rem 1rem; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.2); }
 .table-card { background:#fff; padding:1rem; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.2); }
 .scans-table { width:100%; border-collapse:collapse; font-size:0.9rem; }
@@ -28,22 +38,22 @@ body {
 .header {
   background: rgba(255,255,255,0.95);
   border-radius: 20px;
-  padding: 2rem 2rem 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
   box-shadow: 0 10px 30px rgba(0,0,0,0.2);
   backdrop-filter: blur(10px);
   overflow: hidden;
 }
 h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-shadow:2px 2px 4px rgba(0,0,0,0.1); }
 #reader {
-  width:100%; max-width:600px; height:200px; margin:0 auto 1rem; border-radius:15px;
+  width:100%; max-width:600px; height:200px; margin:0 auto 0.5rem; border-radius:15px;
   box-shadow:0 8px 25px rgba(0,0,0,0.3); background:#fff; padding:15px;
   display:block; border:3px solid #4c51bf;
 }
 #reader video { width:100%!important; height:100%!important; border-radius:12px; object-fit:cover; }
 #reader #qr-shaded-region, #reader canvas { display:none!important; }
 #result {
-  margin:1.5rem 0; font-size:1.2rem; font-weight:600; min-height:3em; padding:1rem;
+  margin:0.5rem 0; font-size:1.2rem; font-weight:600; min-height:3em; padding:0.8rem;
   border-radius:15px; background:rgba(255,255,255,0.9); backdrop-filter:blur(5px);
   display:flex; align-items:center; justify-content:center; transition:all 0.3s ease;
   position:sticky; top:0; z-index:10;
@@ -63,7 +73,7 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-sh
 .scan-btn .emoji { font-size:1.2em; filter:drop-shadow(2px 2px 4px rgba(0,0,0,0.2)); }
 #scan-log {
   margin-top:1rem; text-align:left; background:rgba(255,255,255,0.95);
-  padding:2rem; border-radius:20px; box-shadow:0 10px 30px rgba(0,0,0,0.2); backdrop-filter:blur(10px);
+  padding:1rem; border-radius:20px; box-shadow:0 10px 30px rgba(0,0,0,0.2); backdrop-filter:blur(10px);
 }
 .section-header {
   font-size:1.2rem; font-weight:700; color:#4c51bf; margin-bottom:1rem; padding-bottom:0.5rem;
@@ -91,9 +101,6 @@ h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-sh
   font-weight:700; color:#333; font-size:0.9rem; text-transform:uppercase; letter-spacing:0.5px;
   box-shadow:0 1px 2px rgba(0,0,0,0.1); border:2px solid rgba(255,255,255,0.5);
 }
-.order-tag.success { background:rgba(16,185,129,0.2); border-color:#10b981; }
-.order-tag.warning { background:rgba(245,158,11,0.2); border-color:#f59e0b; }
-.order-tag.error { background:rgba(239,68,68,0.2); border-color:#ef4444; }
 .tag-count { transition:all 0.3s ease; cursor:pointer; }
 .tag-count:hover { transform:scale(1.05); box-shadow:0 4px 12px rgba(0,0,0,0.2); }
 .tag-count.active { outline:3px solid #4c51bf; }


### PR DESCRIPTION
## Summary
- hide info banner from QR scanner
- color order tags based on delivery company
- tighten layout to show more scanned orders
- enlarge tab buttons for easier switching

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882c1ead26883219dbd9d8ca8664f1b