### PR TITLE
Add recent scan cutoff logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ similar mechanism.  Cloud Run reads these values from the service configuration.
 | `GOOGLE_SHEET_ID` | *(optional)* ID of the Google Sheet used for logging scans. |
 | `GCP_SA_B64` | *(optional)* Base64‑encoded service account JSON with access to the sheet. |
 | `STATIC_FILES_PATH` | *(optional)* Location of the built frontend files. Defaults to `static`. |
+| `RECENT_SCAN_DAYS` | *(optional)* Number of days after which a previous scan is still considered recent when checking for duplicates. Defaults to `7`. |
 
 Example `.env` snippet:
 


### PR DESCRIPTION
## Summary
- add RECENT_SCAN_DAYS constant to configure duplicate detection window
- reject duplicate scans only when an existing scan is newer than cutoff
- extend tests for recent and old scans
- document `RECENT_SCAN_DAYS` in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cca0d3d4832181df4a531605a522