### PR TITLE
Cache gspread objects

### DIFF
--- a/backend/app/sheets.py
+++ b/backend/app/sheets.py
@@ -6,15 +6,23 @@ import asyncio
 from google.oauth2.service_account import Credentials
 
 
+# Cached Google client and worksheet objects
+_client_obj = None
+_worksheet = None
+
+
 _sheet_id = os.getenv("GOOGLE_SHEET_ID")
 _sa_b64 = os.getenv("GCP_SA_B64")
 
 
 def _client():
-    creds_dict = json.loads(base64.b64decode(_sa_b64))
-    scopes = ["https://www.googleapis.com/auth/spreadsheets"]
-    creds = Credentials.from_service_account_info(creds_dict, scopes=scopes)
-    return gspread.authorize(creds)
+    global _client_obj
+    if _client_obj is None:
+        creds_dict = json.loads(base64.b64decode(_sa_b64))
+        scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+        creds = Credentials.from_service_account_info(creds_dict, scopes=scopes)
+        _client_obj = gspread.authorize(creds)
+    return _client_obj
 
 
 async def append_row(values: list[str]):
@@ -23,7 +31,9 @@ async def append_row(values: list[str]):
     loop = asyncio.get_running_loop()
 
     def _write():
-        sh = _client().open_by_key(_sheet_id)
-        ws = sh.worksheet("Scans")
-        ws.append_row(values, value_input_option="RAW")
+        global _worksheet
+        if _worksheet is None:
+            sh = _client().open_by_key(_sheet_id)
+            _worksheet = sh.worksheet("Scans")
+        _worksheet.append_row(values, value_input_option="RAW")
     await loop.run_in_executor(None, _write)


### PR DESCRIPTION
## Summary
- cache Google API clients in `sheets.py`
- reuse cached worksheet for appending rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cec97f588321bb76484889ac15e3