### PR TITLE
Improve delivery tag detection with variants

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,11 +8,23 @@ const tagColors = {
   k: "#ffc0cb",
   big: "#fff176",
   "12livery": "#a5d6a7",
-  "12livrey": "#a5d6a7",
   fast: "#90caf9",
   oscario: "#40e0d0",
   sand: "#ffcc80",
   none: "#f28b82",
+};
+
+// Map tag variants to their canonical form.  Keys and values should be lowercase.
+const tagSynonyms = {
+  k: "k",
+  big: "big",
+  "12livery": "12livery",
+  "12livrey": "12livery",
+  "12 livery": "12livery",
+  fast: "fast",
+  oscario: "oscario",
+  sand: "sand",
+  sandy: "sand",
 };
 
 export default function App() {
@@ -410,5 +422,10 @@ function playErrorSound() {
 
 function detectTag(tagStr) {
   const tokens = (tagStr || "").split(/[,\s]+/).map((t) => t.toLowerCase().trim());
-  return Object.keys(tagColors).find((t) => tokens.includes(t)) || "";
+  for (const tok of tokens) {
+    if (tagSynonyms[tok]) {
+      return tagSynonyms[tok];
+    }
+  }
+  return "";
 }


### PR DESCRIPTION
## Summary
- support strict delivery tag variants on backend
- count canonical delivery tags in summaries
- handle delivery tag variants on the frontend
- test delivery tag variant detection and summary counts

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d3b71b60832192779861a43e2da5