### PR TITLE
Make scanner video responsive

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -87,7 +87,13 @@ export default function App() {
     setShowAgain(false);
 
     let qr = scannerRef.current;
-    const config = { fps: 10, qrbox: { width: 300, height: 200 } };
+    const config = {
+      fps: 10,
+      qrbox: (vw, vh) => {
+        const size = Math.floor(Math.min(vw, vh) * 0.8);
+        return { width: size, height: size };
+      },
+    };
     const onScan = (code) => {
       if (navigator.vibrate) navigator.vibrate(100);
       setResult("⏳ Processing scan...");

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,11 +50,25 @@ body {
 }
 h1 { color: #4c51bf; margin:0 0 1rem; font-size:1.8rem; font-weight:700; text-shadow:2px 2px 4px rgba(0,0,0,0.1); }
 #reader {
-  width:100%; max-width:600px; height:200px; margin:0 auto 0.5rem; border-radius:15px;
-  box-shadow:0 8px 25px rgba(0,0,0,0.3); background:#fff; padding:15px;
-  display:block; border:3px solid #4c51bf;
+  width:100%;
+  max-width:600px;
+  height:auto;
+  aspect-ratio:4/3;
+  max-height:80vh;
+  margin:0 auto 0.5rem;
+  border-radius:15px;
+  box-shadow:0 8px 25px rgba(0,0,0,0.3);
+  background:#fff;
+  padding:15px;
+  display:block;
+  border:3px solid #4c51bf;
 }
-#reader video { width:100%!important; height:100%!important; border-radius:12px; object-fit:cover; }
+#reader video {
+  width:100%!important;
+  height:100%!important;
+  border-radius:12px;
+  object-fit:contain;
+}
 #reader #qr-shaded-region, #reader canvas { display:none!important; }
 #result {
   margin:0.5rem 0; font-size:1.2rem; font-weight:600; min-height:3em; padding:0.8rem;


### PR DESCRIPTION
## Summary
- use aspect ratio and max-height for scanner container
- contain video to avoid cropping
- size QR box dynamically based on viewfinder

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882d9cecd0c8321bac124f4b3419351