### PR TITLE
Implement date-filtered tag summary

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -152,7 +152,9 @@ export default function App() {
   }
 
   async function fetchSummary() {
-    const res = await fetch(`${apiBase}/tag-summary`);
+    const url = new URL(`${apiBase}/tag-summary`, window.location.origin);
+    url.searchParams.set("date", new Date().toISOString().slice(0, 10));
+    const res = await fetch(url.toString());
     const data = await res.json();
     setSummary(data);
   }


### PR DESCRIPTION
## Summary
- filter `/tag-summary` results by day
- adjust UI to request today's summary data
- update tests for new behaviour and add a date filtering test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d9b9d1bc8321882a5c799886945c